### PR TITLE
serializing nest objects, deleting organizer_id, because this isnt returning for the reason that, the object returned was serialized

### DIFF
--- a/src/pagination/paginator.ts
+++ b/src/pagination/paginator.ts
@@ -1,3 +1,4 @@
+import { Expose } from "class-transformer";
 import { off } from "process";
 import { SelectQueryBuilder } from "typeorm";
 
@@ -7,11 +8,19 @@ export interface PaginateOptions{
     total?:boolean;
 }
 
-export interface PaginationResult<T>{
+export class PaginationResult<T>{
+    constructor(partial:Partial<PaginationResult<T>>){
+        Object.assign(this,partial)
+    }
+    @Expose()
     first: number;
+    @Expose()
     last:number;
+    @Expose()
     limit:number;
+    @Expose()
     total?:number;
+    @Expose()
     data:T[];
 }
 
@@ -24,11 +33,11 @@ export async function paginate<T>(
 ):Promise<PaginationResult<T>>{
     const offset = (options.currentPage - 1) * options.limit;
     const data = await qb.limit(options.limit).offset(offset).getMany();
-    return{
+    return new PaginationResult({
         first:offset + 1,
         last: offset + data.length,
         limit:options.limit,
         total: options.total ? await qb.getCount():null,
         data
-    }
+    })
 }


### PR DESCRIPTION
serializing nest objects, deleting organizer_id, because this isnt returning for the reason that, the object returned was serialized